### PR TITLE
Add owner_containerconfigs

### DIFF
--- a/psql/permissions/owners.sql
+++ b/psql/permissions/owners.sql
@@ -40,3 +40,23 @@ CREATE POLICY select_billing ON app_private.owner_subscriptions FOR SELECT USING
 GRANT SELECT ON app_private.owner_subscriptions TO asyncy_visitor;
 
 -- Do not grant INSERT, UPDATE, DELETE - these permissions are managed by the system, not users.
+
+----
+
+ALTER TABLE owner_containerconfigs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY select_own ON owner_containerconfigs FOR SELECT USING (owner_uuid = current_owner_uuid());
+CREATE POLICY select_organization ON owner_containerconfigs FOR SELECT USING (owner_uuid = ANY (current_owner_organization_uuids()));
+GRANT SELECT ON owner_containerconfigs TO asyncy_visitor;
+
+CREATE POLICY insert_own ON owner_containerconfigs FOR INSERT WITH CHECK (owner_uuid = current_owner_uuid());
+CREATE POLICY insert_organization ON owner_containerconfigs FOR INSERT WITH CHECK (current_owner_has_organization_permission(owner_uuid, 'CREATE_APP'));
+GRANT INSERT ON owner_containerconfigs TO asyncy_visitor;
+
+CREATE POLICY update_own ON owner_containerconfigs FOR UPDATE USING (owner_uuid = current_owner_uuid());
+CREATE POLICY update_organization ON owner_containerconfigs FOR UPDATE USING (current_owner_has_organization_permission(owner_uuid, 'CREATE_APP'));
+GRANT UPDATE ON owner_containerconfigs TO asyncy_visitor;
+
+CREATE POLICY delete_own ON owner_containerconfigs FOR DELETE USING (owner_uuid = current_owner_uuid());
+CREATE POLICY delete_organization ON owner_containerconfigs FOR DELETE USING (current_owner_has_organization_permission(owner_uuid, 'CREATE_APP'));
+GRANT DELETE ON owner_containerconfigs TO asyncy_visitor;

--- a/psql/tables/owners.sql
+++ b/psql/tables/owners.sql
@@ -66,7 +66,7 @@ CREATE TABLE owner_containerconfigs (
   containerconfig         jsonb not null,
   UNIQUE (owner_uuid, name)
 );
-COMMENT on column owner_containerconfigs.containerconfig is 'Docker config containing the auth credentials';
+COMMENT on column owner_containerconfigs.containerconfig is 'Container config containing the auth credentials';
 
 CREATE TABLE app_private.owner_vcs_secrets (
   owner_vcs_uuid      uuid primary key references owner_vcs on delete cascade,

--- a/psql/tables/owners.sql
+++ b/psql/tables/owners.sql
@@ -59,6 +59,15 @@ CREATE TABLE owner_emails (
 
 CREATE UNIQUE INDEX ON owner_emails(owner_uuid, email); -- This index serves two purposes
 
+CREATE TABLE owner_containerconfigs (
+  uuid                    uuid default uuid_generate_v4() primary key,
+  owner_uuid              uuid not null references owners on delete cascade,
+  name                    varchar(45) not null,
+  containerconfig         jsonb not null,
+  UNIQUE (owner_uuid, name)
+);
+COMMENT on column owner_containerconfigs.containerconfig is 'Docker config containing the auth credentials';
+
 CREATE TABLE app_private.owner_vcs_secrets (
   owner_vcs_uuid      uuid primary key references owner_vcs on delete cascade,
   oauth_token             varchar(45)


### PR DESCRIPTION
See https://github.com/storyscript/platform-engine/issues/299

This table will store docker configurations to be used by the engine for pulling private images.
Given a pull url for an image used in an app deployment, the engine will:
1. Fetch all docker_configs applicable to that pull url owned by the app owner
3. Create kubernetes ImagePullSecrets from those configs, and pass them in the pod spec. 
