### PR TITLE
feat(functions): get_service_repository

### DIFF
--- a/psql/functions/get_service_repository.sql
+++ b/psql/functions/get_service_repository.sql
@@ -1,7 +1,7 @@
 CREATE TYPE app_public.service_repository AS (
   service     app_public.git_service,
   owner_name  app_public.username,
-  name        app_public.username
+  repo_name   app_public.username
 );
 
 CREATE FUNCTION app_public.get_service_repository(service_uuid uuid) RETURNS app_public.service_repository AS $$
@@ -11,6 +11,6 @@ CREATE FUNCTION app_public.get_service_repository(service_uuid uuid) RETURNS app
   INNER JOIN app_public.owner_vcs o ON (o.uuid = r.owner_vcs_uuid)
   WHERE s.uuid = service_uuid
   LIMIT 1
-$$ LANGUAGE sql STABLE SECURITY DEFINER SET search_path FROM CURRENT;
+$$ LANGUAGE sql STABLE SET search_path FROM CURRENT;
 
 COMMENT ON FUNCTION app_public.get_service_repository(uuid) IS E'Return the repository information for a single service.';

--- a/psql/functions/get_service_repository.sql
+++ b/psql/functions/get_service_repository.sql
@@ -1,0 +1,16 @@
+CREATE TYPE app_public.service_repository AS (
+  service     app_public.git_service,
+  owner_name  app_public.username,
+  name        app_public.username
+);
+
+CREATE FUNCTION app_public.get_service_repository(service_uuid uuid) RETURNS app_public.service_repository AS $$
+  SELECT o.service AS service, o.username AS owner_name, r.name AS name
+  FROM app_public.services s
+  INNER JOIN app_hidden.repos r ON (r.uuid = s.repo_uuid)
+  INNER JOIN app_public.owner_vcs o ON (o.uuid = r.owner_vcs_uuid)
+  WHERE s.uuid = service_uuid
+  LIMIT 1
+$$ LANGUAGE sql STABLE SECURITY DEFINER SET search_path FROM CURRENT;
+
+COMMENT ON FUNCTION app_public.get_service_repository(uuid) IS E'Return the repository information for a single service.';

--- a/psql/functions/get_service_repository.sql
+++ b/psql/functions/get_service_repository.sql
@@ -5,7 +5,7 @@ CREATE TYPE app_public.service_repository AS (
 );
 
 CREATE FUNCTION app_public.get_service_repository(service_uuid uuid) RETURNS app_public.service_repository AS $$
-  SELECT o.service AS service, o.username AS owner_name, r.name AS name
+  SELECT o.service AS service, o.username AS owner_name, r.name AS repo_name
   FROM app_public.services s
   INNER JOIN app_hidden.repos r ON (r.uuid = s.repo_uuid)
   INNER JOIN app_public.owner_vcs o ON (o.uuid = r.owner_vcs_uuid)

--- a/psql/functions/main.sql
+++ b/psql/functions/main.sql
@@ -6,6 +6,7 @@
 -- Custom query functions (exposed to GraphQL)
 \ir viewer.sql
 \ir search_terms_to_tsquery.sql
+\ir get_service_repository.sql
 \ir search_services.sql
 \ir convert_to_hostname.sql
 \ir random.sql


### PR DESCRIPTION
- [x] add get_service_repository function to the app_public schema
- [x] add the function to the list of main functions

**Why**
We needed a way to get the repository informations of a service without exposing the `repos` db.

**How**
This function, available to GraphQL public visitors returns a `serviceRepository` object containing the repository name, the service used and the owner name associated to it, e.g. `{ name: 'omg-validate', ownerName: 'omg-services', service: 'GITHUB'}`

**Concerns**
The `repos.name` has a `username` type, so does this new `serviceRepository` type. However, we have the issue #66 which define a potential error based from the repository name regex.