### PR TITLE
Add table to capture metadata for OpenAPI services

### DIFF
--- a/migrations/8.sql
+++ b/migrations/8.sql
@@ -1,0 +1,10 @@
+CREATE TABLE app_public.external_service_metadata(
+    service_uuid            uuid primary key references app_public.services on delete cascade not null,
+    document_uri            text not null,
+    properties              jsonb not null,
+    last_seen_hash          text not null
+);
+
+COMMENT on column external_service_metadata.document_uri is 'The URI of the OpenAPI document';
+COMMENT on column external_service_metadata.properties is 'The properties submitted at service creation, provided to the OMG converter alongside the document';
+COMMENT on column external_service_metadata.last_seen_hash is 'The hash of the document when last converted (in either sucess or failure cases)';

--- a/psql/tables/external_service_metadata.sql
+++ b/psql/tables/external_service_metadata.sql
@@ -1,0 +1,10 @@
+CREATE TABLE app_public.external_service_metadata(
+    service_uuid            uuid primary key references app_public.services on delete cascade not null,
+    document_uri            text not null,
+    properties              jsonb not null,
+    last_seen_hash          text not null
+);
+
+COMMENT on column external_service_metadata.document_uri is 'The URI of the OpenAPI document';
+COMMENT on column external_service_metadata.properties is 'The properties submitted at service creation, provided to the OMG converter alongside the document';
+COMMENT on column external_service_metadata.last_seen_hash is 'The hash of the document when last converted (in either sucess or failure cases)';

--- a/psql/tables/main.sql
+++ b/psql/tables/main.sql
@@ -9,3 +9,4 @@
 \ir tokens.sql
 \ir subscriptions.sql
 \ir beta_users.sql
+\ir external_service_metadata.sql


### PR DESCRIPTION
This PR adds a table to store metadata for OpenAPI services. It contains:
 - a foreign key to the service uuid
 - a field that contains the uri to the OpenAPI document submitted
 - a field containing properties submitted on the front end as a json blob
 - a field containing the sha256 hashed document the last time it was fetched to allow the OpenAPIWatcher component to be smart about when to update and when to email on failure/success.