### PR TITLE
fix(alias): update alias constraint to be less permissive

### DIFF
--- a/deploy/fix_alias_type.sql
+++ b/deploy/fix_alias_type.sql
@@ -5,11 +5,8 @@ BEGIN;
 -- drop old constraint
 ALTER DOMAIN app_public.alias DROP CONSTRAINT alias_check;
 
--- replace current services names containing dots with dashes
-UPDATE app_public.services SET name = regexp_replace(name, '\.', '-', '');
-
 -- add new constraint
 ALTER DOMAIN app_public.alias ADD CONSTRAINT alias_check CHECK ((length((VALUE)::text) > 1) AND (length((VALUE)::text) < 25) AND
-                                (VALUE ~ '^[\w]+[\w\-]*[\w]+$'::citext));
+                                (VALUE ~ '^[a-zA-Z][a-zA-Z-_0-9]*$'::citext));
 
 COMMIT;

--- a/deploy/fix_alias_type.sql
+++ b/deploy/fix_alias_type.sql
@@ -7,6 +7,8 @@ ALTER DOMAIN app_public.alias DROP CONSTRAINT alias_check;
 
 -- add new constraint
 ALTER DOMAIN app_public.alias ADD CONSTRAINT alias_check CHECK ((length((VALUE)::text) > 1) AND (length((VALUE)::text) < 25) AND
-                                (VALUE ~ '^[a-zA-Z][a-zA-Z-_0-9]*$'::citext));
+                                (VALUE ~ '^[a-zA-Z][a-zA-Z\-_0-9]*$'::citext));
+
+
 
 COMMIT;

--- a/deploy/fix_alias_type.sql
+++ b/deploy/fix_alias_type.sql
@@ -1,0 +1,15 @@
+-- Deploy storyscript:fix_alias_type to pg
+
+BEGIN;
+
+-- drop old constraint
+ALTER DOMAIN app_public.alias DROP CONSTRAINT alias_check;
+
+-- replace current services names containing dots with dashes
+UPDATE app_public.services SET name = regexp_replace(name, '\.', '-', '');
+
+-- add new constraint
+ALTER DOMAIN app_public.alias ADD CONSTRAINT alias_check CHECK ((length((VALUE)::text) > 1) AND (length((VALUE)::text) < 25) AND
+                                (VALUE ~ '^[\w]+[\w\-]*[\w]+$'::citext));
+
+COMMIT;

--- a/revert/fix_alias_type.sql
+++ b/revert/fix_alias_type.sql
@@ -1,0 +1,12 @@
+-- Revert storyscript:fix_alias_type from pg
+
+BEGIN;
+
+-- remove current constraint
+ALTER DOMAIN app_public.alias DROP CONSTRAINT alias_check;
+
+-- add old constraint, super permissive, allowing dots in service names
+ALTER DOMAIN app_public.alias ADD CONSTRAINT alias_check CHECK ((length((VALUE)::text) > 1) AND (length((VALUE)::text) < 25) AND
+                                (VALUE ~ '^[\w\-\.]+$'::citext));
+
+COMMIT;

--- a/sqitch.plan
+++ b/sqitch.plan
@@ -5,3 +5,4 @@
 bootstrap 2019-09-23T18:56:51Z Anukul Sangwan <anukulsangwan@icloud.com> # Bootstrap database
 source_code 2019-10-06T05:30:42Z Anukul Sangwan <anukulsangwan@icloud.com> # Store release source code
 add_source_code_rls 2019-10-07T13:00:24Z Anukul Sangwan <anukulsangwan@icloud.com> # Allow inserting releases.source_code
+fix_alias_type 2019-10-08T12:41:41Z Jean Barriere <jean@storyscript.io> # Alias type regex shall be [\\w\\-] only

--- a/verify/fix_alias_type.sql
+++ b/verify/fix_alias_type.sql
@@ -1,7 +1,17 @@
 -- Verify storyscript:fix_alias_type on pg
 
+SET search_path TO :search_path;
+
 BEGIN;
 
--- XXX Add verifications here.
+DO $$
+BEGIN
+
+-- checking that no services contain '.' in their names anymore
+ASSERT (SELECT count(*) FROM services WHERE name ~ '\.') = 0, 'cannot have services';
+
+END;
+$$;
+
 
 ROLLBACK;

--- a/verify/fix_alias_type.sql
+++ b/verify/fix_alias_type.sql
@@ -1,0 +1,7 @@
+-- Verify storyscript:fix_alias_type on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;

--- a/verify/fix_alias_type.sql
+++ b/verify/fix_alias_type.sql
@@ -4,14 +4,42 @@ SET search_path TO :search_path;
 
 BEGIN;
 
-DO $$
-BEGIN
+-- Inspired from https://dba.stackexchange.com/a/203937/161921
+create function try_cast(t text)
+    returns alias
+as
+$$
+begin
+    begin
+        return cast(t as alias);
+    exception
+        when others then
+            return null;
+    end;
+end;
+$$
+    language plpgsql;
 
--- checking that no services contain '.' in their names anymore
-ASSERT (SELECT count(*) FROM services WHERE name ~ '\.') = 0, 'cannot have services';
+do
+$$
+    begin
+        assert try_cast('helloworld') is not null;
+        assert try_cast('hello123') is not null;
+        assert try_cast('h2') is not null;
+        assert try_cast('hello_') is not null;
+        assert try_cast('world-') is not null;
+        assert try_cast('hello-world') is not null;
+        assert try_cast('hello_world') is not null;
 
-END;
+        assert try_cast('hello world') is null;
+        assert try_cast('123') is null;
+        assert try_cast('1world') is null;
+        assert try_cast('hello.world') is null;
+        assert try_cast('-') is null;
+        assert try_cast('_') is null;
+        assert try_cast('.') is null;
+        assert try_cast('.helloworld') is null;
+    end;
 $$;
-
 
 ROLLBACK;


### PR DESCRIPTION
:wave: Hello maintainers !

Users are facing trouble trying to access `service.name`, because the compiler throw an [exception](https://github.com/storyscript/storyscript/blob/d514a5d3a940b8653879019576b210d9bf5d5c56/storyscript/compiler/json/Lines.py#L138), and the grammar seems to allow the following [regex](https://github.com/storyscript/storyscript/blob/master/storyscript/parser/Grammar.py#L63): `/[a-zA-Z_][a-zA-Z-\/_0-9]*/`

I've though updating the alias constraint regex from `^[\w\-\.]+$` to `^[\w]+[\w\-]*[\w]+$`.
This still allows numbers in first position, which I don't know if it should be restrained or not.

Based from feedback here, we can change the regex and merge it.

This migration will:
- prevent names to have dots, or hyphens at beginning/end of names (directly protecting the hub submission process, without update)
- changes all existing `service.name` to `service-name` in the current DB

___
_needs approval from @storyscript/backend before merge._